### PR TITLE
Migrating to npm

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -57,7 +57,7 @@
     <gap:plugin name="org.apache.cordova.vibration" />
 
     <!-- Pushwoosh plugin -->
-    <gap:plugin name="com.pushwoosh.plugins.pushwoosh" source="plugins.cordova.io" />
+    <gap:plugin name="pushwoosh-cordova-plugin" source="npm" />
 
     <!-- Define app icon for each platform. -->
     <icon src="icon.png" />


### PR DESCRIPTION
plugins.cordova.io deprecated, new plugins should use npm
